### PR TITLE
Adding noAlt reference support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.6.3] - 2025-12-18
 ### Added
 - Added new reference options, noAlt and ncbi references
+- [GRD-969](https://jira.oicr.on.ca/browse/GRD-969)
 
 ## [2.6.2] - 2025-05-26
 - Re-deployment to enable labels for optional outputs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.3] - 2025-12-18
+### Added
+- Added new reference options, noAlt and ncbi references
+
 ## [2.6.2] - 2025-05-26
 - Re-deployment to enable labels for optional outputs
 - [GRD-948](https://jira.oicr.on.ca/browse/GRD-948)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.4] - 2026-06-29
+### Changed
+- Fixed hg38 reference .fa file which was pointing to hg38_noAlt .fa file
+
 ## [2.6.3] - 2025-12-18
 ### Added
 - Added new reference options, noAlt and ncbi references

--- a/delly.wdl
+++ b/delly.wdl
@@ -25,9 +25,18 @@ Map[String,GenomeResources] resources = {
   },
    "hg38": {
     "rundelly_module": "delly/0.9.1 bcftools/1.9 tabix/0.2.6 hg38/p12 hg38-delly/1.0",
-    "rundelly_fasta": "$HG38_ROOT/hg38_random.fa",
+    "rundelly_fasta": "$HG38_ROOT/hg38_noAlt.fa",
     "rundelly_exclude_list": "$HG38_DELLY_ROOT/human.hg38.excl.tsv"
-   }
+   },
+   "hg38_noAlt": {
+    "rundelly_module": "delly/0.9.1 bcftools/1.9 tabix/0.2.6 hg38-noalt/p12 hg38-delly/1.0",
+    "rundelly_fasta": "$HG38_NOALT_ROOT/hg38_random.fa",
+    "rundelly_exclude_list": "$HG38_DELLY_ROOT/human.hg38.excl.tsv"
+   },
+   "grch38" : {
+    "rundelly_module": "delly/0.9.1 bcftools/1.9 tabix/0.2.6 grch38/p15 hg38-delly/1.0",
+    "rundelly_fasta": "$GRCH38_ROOT/grch38_noAlt.fa",
+    "rundelly_exclude_list": "$HG38_DELLY_ROOT/human.hg38.excl.tsv"
 }
 
 Array[File] inputBams= select_all([inputTumor,inputNormal])

--- a/delly.wdl
+++ b/delly.wdl
@@ -25,7 +25,7 @@ Map[String,GenomeResources] resources = {
   },
    "hg38": {
     "rundelly_module": "delly/0.9.1 bcftools/1.9 tabix/0.2.6 hg38/p12 hg38-delly/1.0",
-    "rundelly_fasta": "$HG38_ROOT/hg38_noAlt.fa",
+    "rundelly_fasta": "$HG38_ROOT/hg38_random.fa",
     "rundelly_exclude_list": "$HG38_DELLY_ROOT/human.hg38.excl.tsv"
    },
    "hg38_noAlt": {

--- a/delly.wdl
+++ b/delly.wdl
@@ -37,6 +37,7 @@ Map[String,GenomeResources] resources = {
     "rundelly_module": "delly/0.9.1 bcftools/1.9 tabix/0.2.6 grch38/p15 hg38-delly/1.0",
     "rundelly_fasta": "$GRCH38_ROOT/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna",
     "rundelly_exclude_list": "$HG38_DELLY_ROOT/human.hg38.excl.tsv"
+   }
 }
 
 Array[File] inputBams= select_all([inputTumor,inputNormal])

--- a/delly.wdl
+++ b/delly.wdl
@@ -30,12 +30,12 @@ Map[String,GenomeResources] resources = {
    },
    "hg38_noAlt": {
     "rundelly_module": "delly/0.9.1 bcftools/1.9 tabix/0.2.6 hg38-noalt/p12 hg38-delly/1.0",
-    "rundelly_fasta": "$HG38_NOALT_ROOT/hg38_random.fa",
+    "rundelly_fasta": "$HG38_NOALT_ROOT/hg38_noAlt.fa",
     "rundelly_exclude_list": "$HG38_DELLY_ROOT/human.hg38.excl.tsv"
    },
    "grch38" : {
     "rundelly_module": "delly/0.9.1 bcftools/1.9 tabix/0.2.6 grch38/p15 hg38-delly/1.0",
-    "rundelly_fasta": "$GRCH38_ROOT/grch38_noAlt.fa",
+    "rundelly_fasta": "$GRCH38_ROOT/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna",
     "rundelly_exclude_list": "$HG38_DELLY_ROOT/human.hg38.excl.tsv"
 }
 


### PR DESCRIPTION
Ainslie had originally made this change but include the hg38_noAlt.fa as the reference file under both hg38 and hg38_noAlt genomic resource. I have fixed this and updated the wdl and changelog. A new tag 2.6.4 is required. 